### PR TITLE
Minor fix to xray_lines documentation.

### DIFF
--- a/python/xraydb/xraydb.py
+++ b/python/xraydb/xraydb.py
@@ -617,7 +617,7 @@ class XrayDB(object):
                  excited by X-rays of this energy (in eV).
 
         Returns:
-            dictionary: keys of lines (iupac symbol), values of Xray Lines
+            dictionary: keys of lines (Siegbahn symbol), values of Xray Lines
 
         Notes:
             if both excitation_energy and initial_level are given, excitation_level


### PR DESCRIPTION
Mistake in the docstring for xray_lines, which said the the output was a dictionary with the iupac symbol as keys.  The actual output of xray_lines() uses 'siegbahn_symbol' as the dictionary key.